### PR TITLE
Add to cart

### DIFF
--- a/client/components/Candy/Candy.js
+++ b/client/components/Candy/Candy.js
@@ -18,7 +18,7 @@ class Candy extends Component{
         <h3>{candy.name}</h3>
         <div>Weight: {candy.weight}</div>
         <div>Price: ${candy.price}</div>
-        <button onClick={()=> this.props.addToCart(candy, this.props.auth)}>Add To Cart</button>
+        <button onClick={()=> this.props.addToCart(candy, this.props.auth, this.props.guestCart)}>Add To Cart</button>
       </div>
     )
   }
@@ -26,8 +26,8 @@ class Candy extends Component{
 
 const mapDispatchToProps = (dispatch)  => {
   return{
-    addToCart: (candy, cart)=>{
-      dispatch(addToCart(candy,cart));
+    addToCart: (candy, auth, guestCart)=>{
+      dispatch(addToCart(candy,auth, guestCart));
     }
   }
 };

--- a/client/components/CandyList/CandyList.js
+++ b/client/components/CandyList/CandyList.js
@@ -12,6 +12,7 @@ class CandyList extends React.Component {
   
   render(){
     const { candies } = this.props;
+    
     return(
       <div>
         <ul>

--- a/client/components/Cart/Cart.js
+++ b/client/components/Cart/Cart.js
@@ -12,7 +12,15 @@ class Cart extends Component{
       return null;
 
     //renders guest cart if no user is logged in.
-    let lineitems
+    let cart = !this.props.auth.id ? this.props.guestCart: this.props.auth.cart;
+
+    //guest cart but it is empty
+    if(!cart.lineitems){
+      return;
+    }
+
+    let lineitems;
+
     if(!this.props.auth.id){
       lineitems = this.props.guestCart.lineitems;
     }
@@ -20,8 +28,6 @@ class Cart extends Component{
       lineitems = this.props.auth.cart.lineitems;
     }
       
-    
-
     return(
       <div>
         <ul>

--- a/client/store/auth.js
+++ b/client/store/auth.js
@@ -40,6 +40,12 @@ export const authenticate = (username, password, method) => async dispatch => {
 
 export const logout = () => {
   window.localStorage.removeItem(TOKEN)
+  //TODO
+  //revisit situation in which cart id would need to be removed from local storage
+  //when a user is a guest shopping and then logs in the guest cart is now that user cart
+  //after the user logs out the once guest cart should no longer exist in local storage
+  //would then need to figure out how to reload a guest cart
+  window.localStorage.removeItem('cart')
   history.push('/login')
   return {
     type: SET_AUTH,

--- a/client/store/cart.js
+++ b/client/store/cart.js
@@ -1,32 +1,27 @@
 import axios from 'axios';
 
-
 const ADD_TO_CART = 'ADD_TO_CART';
 const ADD_TO_CART_GUEST = 'ADD_TO_CART_GUEST';
 
-
 export const addToCart = (candy,auth, guestCart)=>{
   return async(dispatch)=>{
+    const cart = (!window.localStorage.token && guestCart) ? guestCart : auth.cart;
+
+    let line = (!cart.lineitems) ? null : cart.lineitems.find(_line => {
+      return _line.candyId === candy.id;
+    });
+
+    //if no line item exist create one to add to cart
+    if(!line){
+      (await axios.post('/api/lineItem',{cartId:cart.id, qty: 1, candyId: candy.id})).data; 
+    }
+    else{
+      //else update line item in cart 
+      (await axios.put(`/api/lineItem/${line.id}`, {...line, ...{qty: line.qty + 1}}));
+    }
+
     if(!window.localStorage.token && guestCart){
-      let line;
-
-      //if cart is not empty and has lineItems find line with candyId and update
-      if(guestCart.lineitems){
-        line = guestCart.lineitems.find(_line => {
-          return _line.candyId === candy.id;
-        });
-      }
-
-      //if no line item exist create one to add to cart
-      if(!line){
-        (await axios.post('/api/lineItem',{cartId:guestCart.id, qty: 1, candyId: candy.id})).data; 
-      }
-      else{
-        //else update line item in cart 
-        (await axios.put(`/api/lineItem/${line.id}`, {...line, ...{qty: line.qty + 1}}));
-      }
-
-      const updatedcart = (await axios.get(`/api/cart/${guestCart.id}`)).data ;
+      const updatedcart = (await axios.get(`/api/cart/${cart.id}`)).data ;
       guestCart.lineitems = updatedcart.lineitems;
 
       return dispatch({
@@ -35,24 +30,7 @@ export const addToCart = (candy,auth, guestCart)=>{
       })
     }
     else{
-      const cart = auth.cart;
-
-      //find line that has the candyId
-      const line = cart.lineitems.find(_line => {
-        return _line.candyId === candy.id;
-      });
-
-      //if no line item exist create one to add to cart
-      if(!line){
-        (await axios.post('/api/lineItem',{cartId:cart.id, qty: 1, candyId: candy.id})).data; 
-      }
-      else{
-        //else update line item in cart 
-        (await axios.put(`/api/lineItem/${line.id}`, {...line, ...{qty: line.qty + 1}}));
-      }
-
       const updatedcart = (await axios.get('/api/cart/',{headers: {authorization: window.localStorage.token}})).data ;
-
       auth.cart = updatedcart;
 
       return dispatch({

--- a/client/store/cart.js
+++ b/client/store/cart.js
@@ -2,40 +2,60 @@ import axios from 'axios';
 
 
 const ADD_TO_CART = 'ADD_TO_CART';
+const ADD_TO_CART_GUEST = 'ADD_TO_CART_GUEST';
 
 
-export const addToCart = (candy,auth)=>{
+export const addToCart = (candy,auth, guestCart)=>{
   return async(dispatch)=>{
-   
-    const cart = auth.cart;
+    if(!window.localStorage.token && guestCart){
+      let line;
 
-    //TODO
-    if(!window.localStorage.token){
-      //not logged in
-      //get cart from windows local storage
-
-    }
-    else{
-      //if cart exists get all line items with that cart number then search for line item with our candy #
-      const line = cart.lineitems.find(_line => {
-        return _line.candyId === candy.id;
-      })
+      //if cart is not empty and has lineItems find line with candyId and update
+      if(guestCart.lineitems){
+        line = guestCart.lineitems.find(_line => {
+          return _line.candyId === candy.id;
+        });
+      }
 
       //if no line item exist create one to add to cart
       if(!line){
-      await axios.post('/api/lineItem',{cartId:cart.id, qty: 1, candyId: candy.id}); 
+        (await axios.post('/api/lineItem',{cartId:guestCart.id, qty: 1, candyId: candy.id})).data; 
       }
       else{
         //else update line item in cart 
-        await axios.put(`/api/lineItem/${line.id}`, {...line, ...{qty: line.qty + 1}});
+        (await axios.put(`/api/lineItem/${line.id}`, {...line, ...{qty: line.qty + 1}}));
       }
 
-      //need to update cart in auth
-      const updatedcart = (await axios.get('/api/cart/',{headers: {authorization: window.localStorage.token}})).data;
+      const updatedcart = (await axios.get(`/api/cart/${guestCart.id}`)).data ;
+      guestCart.lineitems = updatedcart.lineitems;
+
+      return dispatch({
+        type: ADD_TO_CART_GUEST,
+        guestCart
+      })
+    }
+    else{
+      const cart = auth.cart;
+
+      //find line that has the candyId
+      const line = cart.lineitems.find(_line => {
+        return _line.candyId === candy.id;
+      });
+
+      //if no line item exist create one to add to cart
+      if(!line){
+        (await axios.post('/api/lineItem',{cartId:cart.id, qty: 1, candyId: candy.id})).data; 
+      }
+      else{
+        //else update line item in cart 
+        (await axios.put(`/api/lineItem/${line.id}`, {...line, ...{qty: line.qty + 1}}));
+      }
+
+      const updatedcart = (await axios.get('/api/cart/',{headers: {authorization: window.localStorage.token}})).data ;
 
       auth.cart = updatedcart;
 
-      dispatch({
+      return dispatch({
         type: ADD_TO_CART,
         auth
       })
@@ -46,6 +66,9 @@ export const addToCart = (candy,auth)=>{
 export default (state = {}, action) => {
   if(action.type === ADD_TO_CART){
     return action.auth; 
+  }
+  if(action.type === ADD_TO_CART_GUEST){
+    return action.guestCart;
   }
   return state;
 }

--- a/client/store/guestCart.js
+++ b/client/store/guestCart.js
@@ -9,14 +9,14 @@ export const guestCart = () => {
 
       //if we have a cart id saved in local storage, we fetch the cart.
       //if not, we create a cart and save it in local storage.
-      let cartId = window.localStorage.cart;
-      
+      let cartId = window.localStorage.cartId;
+
       if(!cartId){
         guestCart = (await axios.post('/api/cart')).data;
-        window.localStorage.cart = guestCart.id;
+        window.localStorage.cartId = guestCart.id;
       }
       else{
-        guestCart = (await axios.post('/api/cart', {cartId: window.localStorage.cart})).data
+        guestCart = (await axios.get(`/api/cart/${cartId}`)).data;
       }
 
       dispatch({

--- a/client/store/index.js
+++ b/client/store/index.js
@@ -7,7 +7,7 @@ import candies from './candy';
 import cart from './cart';
 import guestCart from './guestCart';
 
-const reducer = combineReducers({ auth, candies, cart, guestCart });
+const reducer = combineReducers({ auth, candies, guestCart, cart });
 const middleware = composeWithDevTools(
   applyMiddleware(thunkMiddleware, createLogger({collapsed: true}))
 )

--- a/server/api/cart.js
+++ b/server/api/cart.js
@@ -25,33 +25,36 @@ router.get('/', async (req, res, next) => {
   }
 })
 
+router.get('/:id',async(req,res,next)=>{
+  try{
+    const cart = await Cart.findOne({
+      where: {
+        id: req.params.id
+      },
+      include: [{
+        model: LineItem, include: [{
+          model: Candy
+        }]
+      }]
+    });
+    
+    res.send(cart);
+  }
+  catch(err){
+    next(err);
+  }
+});
+
 router.post('/', async (req, res, next) => {
   try{
-    let cart;
-    //if we send this route a cart id, it finds cart and 
-    //returns it. if we don't, then it creates a cart and
-    //returns it.
-    if(req.body.cartId){
-      cart = await Cart.findOne({
-        where: {
-          id: req.body.cartId
-        },
-        include: [{
-          model: LineItem, include: [{
-            model: Candy
-          }]
+    const cart = await Cart.create({},{
+      include: [{
+        model: LineItem, include: [{
+          model: Candy
         }]
-      });
-    }
-    else{
-      cart = await Cart.create({},{
-        include: [{
-          model: LineItem, include: [{
-            model: Candy
-          }]
-        }]
-      });
-    }
+      }]
+    });
+
     res.send(cart);
   }
   catch(err){


### PR DESCRIPTION
Add to cart now works for logged in and logged out users. 

Broke up the post route for cart into post and get with param id to avoid post fetching an existing cart.

Rewrote cart id to be stored in local storage as cartId vs cart.

Encountered an error with cartId in local storage. When data is reseeded and local host is running, local storage keeps cartId in local storage but cart with corresponding id doesn't exist in database anymore so cart is never fetched, but a new cart is never created. Work around for now is removing cartId manually and refreshing the app.

Currently included a line to wipe cartId from local storage when user logs out. Guest cart and user cart would be merged if existing user starts shopping before logging in (not currently implemented), but when they log out it stands to reason that guest cart will no longer exist.